### PR TITLE
Add project dependencies to pyproject.toml

### DIFF
--- a/tomopari/pyproject.toml
+++ b/tomopari/pyproject.toml
@@ -2,6 +2,11 @@
 requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+dependencies = [
+    "torch"
+]
+
 [tool.black]
 line-length = 79
 


### PR DESCRIPTION
Added project section with torch as a dependency

resolves:

```
pip install tomopari
python
>>> import tomopari
ModuleNotFoundError: No module named 'torch'
```